### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,4 +5,4 @@ eureka.client:
   register-with-eureka: false
   fetch-registry: false
 
-netflix.atlas.uri: http://atlas/api/v1/publish/
+netflix.atlas.uri: https://atlas/api/v1/publish/


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://atlas/api/v1/publish/ (UnknownHostException) with 1 occurrences migrated to:  
  https://atlas/api/v1/publish/ ([https](https://atlas/api/v1/publish/) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8761 with 1 occurrences